### PR TITLE
 Schema validation against "maximum" and "minimum" can only take place on numbers and memory leaks

### DIFF
--- a/src/wjelement/schema.c
+++ b/src/wjelement/schema.c
@@ -847,10 +847,11 @@ static XplBool SchemaValidate(WJElement schema, WJElement document,
 #ifdef HAVE_REGEX_H
 			regex_t pat;
 			str = WJEString(memb, NULL, WJE_GET, NULL);
-			if(str && !regcomp(&pat, str, REG_EXTENDED | REG_NOSUB) &&
-			   regexec(&pat, WJEString(document, NULL, WJE_GET, ""),
-					   0, NULL, 0)) {
-				fail = TRUE;
+			if(str && !regcomp(&pat, str, REG_EXTENDED | REG_NOSUB)) {
+				if(regexec(&pat, WJEString(document, NULL, WJE_GET, ""),
+						   0, NULL, 0)) {
+					fail = TRUE;
+				}
 				regfree(&pat);
 			}
 			if(fail && err) {
@@ -940,10 +941,11 @@ static XplBool SchemaValidate(WJElement schema, WJElement document,
 				/* unknown or user-defined format, let it pass */
 			}
 			if(str2 && !regcomp(&freg, str2,
-								REG_ICASE | REG_EXTENDED | REG_NOSUB) &&
-			   regexec(&freg, WJEString(document, NULL, WJE_GET, ""),
-					   0, NULL, 0)) {
-				fail = TRUE;
+								REG_ICASE | REG_EXTENDED | REG_NOSUB)) {
+				if(regexec(&freg, WJEString(document, NULL, WJE_GET, ""),
+						   0, NULL, 0)) {
+					fail = TRUE;
+				}
 				regfree(&freg);
 			}
 			if(fail && err) {


### PR DESCRIPTION
Found an issue with schema validation.
Validating this JSON:

{"id": 1, "type_id": null, "name": null}

against this schema:

{
"type":"object",
"properties":{
    "id":{"type": "integer", "minimum": 1},
    "type_id":{"type": ["integer", "null"], "minimum": 1},
    "name":{"type": ["string", "null"], "maxLength": 5},
    },
"additionalProperties" : false
}

fails on "type_id", when it shouldn’t.

Found also two memory leaks in regcomp() calls.

Best regards,
José Gonçalves
