### PR TITLE
Fixed MSVS build.

### DIFF
--- a/include/xpl.h
+++ b/include/xpl.h
@@ -22,6 +22,7 @@
 #include <limits.h>
 #include <stdarg.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 
 #ifndef XPL_H
@@ -181,11 +182,19 @@ typedef signed char int8;
 
 # define DebugAssert( x )
 
+# if defined(_MSC_VER)
+# define XplStrCaseCmp(a,b) _stricmp(a,b)
+# define stricmp(a,b) _stricmp(a,b)
+
+# define XplStrNCaseCmp(a,b,c) _strnicmp(a,b,c)
+# define strnicmp(a,b,c) _strnicmp(a,b,c)
+#else
 # define XplStrCaseCmp(a,b) strcasecmp(a,b)
 # define stricmp(a,b) strcasecmp(a,b)
 
 # define XplStrNCaseCmp(a,b,c) strncasecmp(a,b,c)
 # define strnicmp(a,b,c) strncasecmp(a,b,c)
+#endif
 
 EXPORT char *_skipspace( char *source, const char *breakchars );
 #define skipspace(s) _skipspace((s), "\r\n")
@@ -196,5 +205,9 @@ EXPORT int stripat(char *str, char *pattern);
 EXPORT int stripatn(char *str, char *pattern, size_t len);
 
 EXPORT char * strspace( char *source );
+
+#if defined(_WIN32)
+EXPORT char * strndup(char* p, size_t maxlen);
+#endif
 
 #endif

--- a/src/lib/xpl.c
+++ b/src/lib/xpl.c
@@ -17,6 +17,7 @@
 
 
 #include <xpl.h>
+#include <ctype.h>
 #include <string.h>
 
 /* hack for aix, windows, and other asprintf-less systems */
@@ -290,3 +291,21 @@ EXPORT char * strspace( char *source )
 	return NULL;
 }
 
+#if defined(_WIN32)
+EXPORT char * strndup( char *p, size_t maxlen )
+{
+	if( p )
+	{
+		char *r = malloc( maxlen + 1 );
+		if( !r )
+		{
+			return r;	
+		}
+		strncpy( r, p, maxlen );
+		r[maxlen] = '\0';
+		return r;
+	}
+
+	return NULL;
+}
+#endif

--- a/src/wjelement/schema.c
+++ b/src/wjelement/schema.c
@@ -17,6 +17,7 @@
 
 
 #include "element.h"
+#include <ctype.h>
 #include <stdlib.h>
 #include <sys/types.h>
 #ifdef HAVE_REGEX_H

--- a/src/wjelement/search.c
+++ b/src/wjelement/search.c
@@ -17,6 +17,7 @@
 
 
 #include "element.h"
+#include <ctype.h>
 
 /*
 	Return the element that would be 'next' if the 'root' element was flattened

--- a/src/wjreader/wjreader.c
+++ b/src/wjreader/wjreader.c
@@ -16,6 +16,7 @@
 */
 
 
+#include <ctype.h>
 #include <string.h>
 #include <stdlib.h>
 
@@ -24,6 +25,11 @@
 #include <memmgr.h>
 
 #include <wjreader.h>
+
+#if defined(_MSC_VER)
+#define strtoull(nptr, endptr, base) _strtoui64(nptr, endptr, base)
+#define strtoll(nptr, endptr, base) _strtoi64(nptr, endptr, base)
+#endif
 
 /*
 	JSON syntax (http://www.json.org/)

--- a/src/wjwriter/wjwriter.c
+++ b/src/wjwriter/wjwriter.c
@@ -25,6 +25,11 @@
 
 #include <wjwriter.h>
 
+#if defined(_MSC_VER)
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#endif
+
 /*
 	JSON syntax (http://www.json.org/)
 	==================================


### PR DESCRIPTION
Added missing headers, functions and types.
Still has warnings, but now library is compilable with msvs.
Compilation tested with MSVS Express 2013 Preview, MinGW 4.6.2, gcc 4.7.2 (Ubuntu).
