### PR TITLE
Fix default value in WJEDouble get.

### DIFF
--- a/src/wjelement/types.c
+++ b/src/wjelement/types.c
@@ -657,7 +657,7 @@ EXPORT double __WJEDouble(WJElement container, char *path, WJEAction action, WJE
 					break;
 
 				default:
-					return(0);
+					return(value);
 			}
 
 		case WJE_SET:


### PR DESCRIPTION
Unlike integer manipulation functions, WJEDouble is not returning the default value when an element has a null value.
