### PR TITLE
Add .gitignore for untracked CMake / build files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# CMake files
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Makefile
+CTestTestfile.cmake
+cmake_install.cmake
+cmake_uninstall.cmake
+install_manifest.txt
+
+# Output files
+wjelement.pc
+wjecli
+wjeunit
+libxpl.so
+libxpl.so.*
+libwjelement.so
+libwjelement.so.*
+libwjreader.so
+libwjreader.so.*
+libwjwriter.so
+libwjwriter.so.*


### PR DESCRIPTION
This makes it easier for contributors to manage their changes while they are building and testing and have a dirty working tree after running `cmake .`.