### PR TITLE
Fix null-termination bug in WJEWriteMEM.

### DIFF
--- a/src/wjelement/element.c
+++ b/src/wjelement/element.c
@@ -702,5 +702,5 @@ EXPORT char * WJEWriteMEM(WJElement document, XplBool pretty, size_t maxlength)
 		WJEWriteDocument(document, memWriter, NULL);
 		WJWCloseDocument(memWriter);
 	}
-	return MemRealloc(data.buffer, strlen(data.buffer));
+	return MemRealloc(data.buffer, strlen(data.buffer) + 1);
 }


### PR DESCRIPTION
WJEWriteMEM contains a realloc which uses strlen to shrink a buffer down to the string it contains. Strlen does not factor in the null-terminator, so strlen + 1 should be used here.