### PR TITLE
Add missing EXPORT attribute to the asprintf function declaration

### DIFF
--- a/include/memmgr.h
+++ b/include/memmgr.h
@@ -28,7 +28,7 @@
 #include <stdio.h>
 
 #ifndef asprintf
-	int asprintf(char **strp, const char *fmt, ...);
+	EXPORT int asprintf(char **strp, const char *fmt, ...);
 #else
 #define HAS_ASPRINTF
 #endif


### PR DESCRIPTION
Not sure if this is the correct approach. I needed to add the EXPORT to match the definition in xpl.c when compiling with MSVC 2013 32bit.