### PR TITLE
Rename min/max macros to fix stdlib naming clash

### DIFF
--- a/include/xpl.h
+++ b/include/xpl.h
@@ -55,12 +55,12 @@
 
 /* xpldefs.h */
 
-#ifndef min
-#define min(a, b)   (((a) < (b))? (a): (b))
+#ifndef xpl_min
+#define xpl_min(a, b)   (((a) < (b))? (a): (b))
 #endif
 
-#ifndef max
-#define max(a, b)   (((a) > (b))? (a): (b))
+#ifndef xpl_max
+#define xpl_max(a, b)   (((a) > (b))? (a): (b))
 #endif
 
 

--- a/src/wjreader/wjreader.c
+++ b/src/wjreader/wjreader.c
@@ -863,7 +863,7 @@ EXPORT char * WJRNext(char *parent, size_t maxnamelen, WJReader indoc)
 										Cut off any portion of the string that
 										isn't needed
 									*/
-									name[min(maxnamelen, length)] = '\0';
+									name[xpl_min(maxnamelen, length)] = '\0';
 
 									/*
 										Determine where the name needs to go.

--- a/src/wjwriter/wjwriter.c
+++ b/src/wjwriter/wjwriter.c
@@ -175,7 +175,7 @@ static int WJWrite(WJIWriter *doc, char *data, size_t length)
 	while (length) {
 		/* Fill our buffer as much as possible */
 		if (doc->used < doc->size) {
-			size = min(length, doc->size - doc->used);
+			size = xpl_min(length, doc->size - doc->used);
 
 			memcpy(doc->buffer + doc->used, data, size);
 			result		+= size;


### PR DESCRIPTION
* Addresses issue #49
* Renamed to xpl_min and xpl_max