### PR TITLE
Fixed install when built using add_subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ CONFIGURE_FILE(
   "${CMAKE_CURRENT_SOURCE_DIR}/pkg-config.pc.cmake"
   "${CMAKE_CURRENT_BINARY_DIR}/wjelement.pc"
 )
-INSTALL(FILES "${CMAKE_BINARY_DIR}/wjelement.pc"
+INSTALL(FILES "${CMAKE_CURRENT_BINARY_DIR}/wjelement.pc"
         DESTINATION ${LIB_DEST_DIR}/pkgconfig)
 
 # uninstall target


### PR DESCRIPTION
When using the library as a CMake subdirectory the CMAKE_CURRENT_BINARY_DIR variable changes which makes it different than CMAKE_BINARY_DIR, causing install to fail. This fixes that.