### PR TITLE
Completely ignore empty input lines with _skipspace(breakchars=NULL)

### DIFF
--- a/src/cli/wjecli.c
+++ b/src/cli/wjecli.c
@@ -255,7 +255,7 @@ int main(int argc, char **argv)
 		}
 
 		if (fgets(line, sizeof(line), in)) {
-			cmd = skipspace(line);
+			cmd = _skipspace(line, NULL);
 		} else {
 			cmd = NULL;
 		}


### PR DESCRIPTION
Hi, I'd like to offer a little change so that empty input line wouldn't cause segfault in wjecli.