### PR TITLE
docs: fix simple typo, existance -> existence

### DIFF
--- a/src/wjelement/search.c
+++ b/src/wjelement/search.c
@@ -203,7 +203,7 @@ static int WJEMatchSubscript(WJElement root, WJElement parent, WJElement e, WJEA
 		Walk through all items in the subscript and do the proper check on each
 		piece.  Return 0 on the first match.
 
-		The name has already been validated, so the existance of a closing ] is
+		The name has already been validated, so the existence of a closing ] is
 		a sure thing, and any quoted string will be terminated.
 	*/
 	char		*p;

--- a/src/wjelement/types.c
+++ b/src/wjelement/types.c
@@ -95,7 +95,7 @@ EXPORT XplBool __WJEBool(WJElement container, const char *path, WJEAction action
 
 				case WJR_TYPE_OBJECT:
 				case WJR_TYPE_ARRAY:
-					/* TRUE based on the existance of the object */
+					/* TRUE based on the existence of the object */
 					return(TRUE);
 
 				case WJR_TYPE_STRING:

--- a/src/wjreader/wjreader.c
+++ b/src/wjreader/wjreader.c
@@ -1450,7 +1450,7 @@ EXPORT double WJRDouble(WJReader doc)
 
 /*
 	Parse the number in the JSON document as either a UInt64 or a double,
-	depending on the existance of a decimal point.
+	depending on the existence of a decimal point.
 
 	Return TRUE if there was a decimal point, and fill out *d. If there is no
 	decimal point then return FALSE and fill out *i.


### PR DESCRIPTION
There is a small typo in src/wjelement/search.c, src/wjelement/types.c, src/wjreader/wjreader.c.

Should read `existence` rather than `existance`.

