### PR TITLE
Fix memory leak

### DIFF
--- a/src/wjelement/element.c
+++ b/src/wjelement/element.c
@@ -814,7 +814,7 @@ EXPORT void WJEMemFree(void *mem)
 }
 EXPORT void WJEMemRelease(void **mem)
 {
-	if(mem != NULL && !*mem != NULL) {
+	if(mem != NULL && *mem != NULL) {
 		MemRelease(mem);
 	}
 }


### PR DESCRIPTION
The "WJEMemRelease" function does not release memory as expected due to incorrect validation of the memory pointer passed as argument.