### PR TITLE
Add some do {} while (0) statement into ./include/memmgr.h

### DIFF
--- a/include/memmgr.h
+++ b/include/memmgr.h
@@ -45,8 +45,8 @@
 #define MemMallocWait( s )						malloc( (s) )
 #define MemFree( p )							free( (p) )
 #define MemFreeEx( p, f, l )					free( (p) )
-#define MemRelease( p )							free( (*p) ); (*p) = NULL
-#define MemReleaseEx( p, f, l )					free( (*p) ); (*p) = NULL
+#define MemRelease( p )							do { free( (*p) ); (*p) = NULL; } while (0)
+#define MemReleaseEx( p, f, l )					do { free( (*p) ); (*p) = NULL; } while (0)
 #define MemRealloc( p, s )						realloc( (p), (s) )
 #define MemReallocWait( p, s )					realloc( (p), (s) )
 #define MemStrdup( s )							strdup( (s) )


### PR DESCRIPTION
Hello, 

We use your librairie in our project but we had to add some do {} while (0) statements in one include.
It is into ./include/memmgr.h and on #define MemRelease( p ) and #define MemReleaseEx( p, f, l )

We need to do that because if we use your #define without do while (0) statement, we could have compilation problems, specially if we use that #define into an if without {}.

And I think that we found this type of utilization into your own code. Really sorry to notice that.

Thanks a lot for your attention.
See you.
Joël.
