### PR TITLE
Add a NULL initial value to doc into __WJEFromString() in element.c.

### DIFF
--- a/src/wjelement/element.c
+++ b/src/wjelement/element.c
@@ -398,7 +398,7 @@ static size_t WJEMemCallback(char *buffer, size_t length, size_t seen, void *use
 */
 EXPORT WJElement __WJEFromString(const char *json, char quote, const char *file, const int line)
 {
-	WJElement		doc;
+	WJElement		doc = NULL;
 	WJEMemArgs		args;
 	WJReader		reader;
 


### PR DESCRIPTION
Hello,

We have compilation problem when we want to use your lib in our project. Due to -Wall and -Werror flags, our compiler doesn't want uninitialized pointer but in element.c, we find a doc variable (WJElement doc) that is not really initialized (into __WJEFromString() ).
To correct that, I simply added a "= NULL" on the declaration line of this variable.

Could you, please, consider this is good and accept the PR ?

Thanks a lot.
Joël.