### PR TITLE
Fix MemAsprintf() return value into include/memmgr.h.

### DIFF
--- a/include/memmgr.h
+++ b/include/memmgr.h
@@ -54,7 +54,7 @@
 #define MemStrndup( s, m )						strndup( (s), (m) )
 #define MemStrndupWait( s, m )					strndup( (s), (m) )
 #define MemSprintf( f, ... )					sprintf( (f), __VA_ARGS__ )
-#define MemAsprintf( p, f, ... )				asprintf( (p), (f), __VA_ARGS__ )
+#define MemAsprintf( p, f, ... )				(void)!asprintf( (p), (f), __VA_ARGS__ )
 #define MemCalloc( c, s )						calloc( (c), (s) )
 #define MemCallocWait( c, s )					calloc( (c), (s) )
 


### PR DESCRIPTION
Hello,

We have compilation problem when we want to use your lib in our project. Due to -Wall and -Werror flags, our compiler doesn't want to have unused return value but in include/memmgr.h, we find a macro that is not in compliance with this way of doing. This is MemAsprintf().

I can propose you a simple modification on the macro by adding a simple "(void)!" before the asprintf().

Could you, please, consider this is good and accept the PR ?

Thanks a lot.
Joël.
