### PR TITLE
Encode vertical tab character correctly - Issue #110

### DIFF
--- a/src/wjwriter/wjwriter.c
+++ b/src/wjwriter/wjwriter.c
@@ -459,7 +459,6 @@ static XplBool WJWriteString(char *value, size_t length, XplBool done, WJIWriter
 			case '\n':	*(esc + 1) = 'n';	break;
 			case '\b':	*(esc + 1) = 'b';	break;
 			case '\t':	*(esc + 1) = 't';	break;
-			case '\v':	*(esc + 1) = 'v';	break;
 			case '\f':	*(esc + 1) = 'f';	break;
 			case '\r':	*(esc + 1) = 'r';	break;
 


### PR DESCRIPTION
Hi,

this is a pull request for issue #110.

The vertical tab character ('\v', 0xB) is not in the list of characters to be encoded on json.org.
Encoding it with backslash causes a JSON parsing error in some browsers (at least in chrome). Encode it as unicode instead (\u000b).

Thank you!