### PR TITLE
Flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ ipch/
 *.user
 *.tlog
 
+# nix build result dir
+result

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ ipch/
 
 # nix build result dir
 result
+
+# direnv working directory
+.direnv

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(WJElement)
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.5)
 include(CheckIncludeFiles)
 include(CheckSymbolExists)
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1774106199,
+        "narHash": "sha256-US5Tda2sKmjrg2lNHQL3jRQ6p96cgfWh3J1QBliQ8Ws=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6c9a78c09ff4d6c21d0319114873508a6ec01655",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,52 @@
+{
+	description = "Development flake";
+	inputs = {
+		nixpkgs.url	= "github:NixOS/nixpkgs/nixos-unstable";
+		utils.url	= "github:numtide/flake-utils";
+	};
+
+	outputs = { nixpkgs, ... }@inputs: inputs.utils.lib.eachDefaultSystem (system:
+		let
+			pkgs = import nixpkgs {
+				inherit system;
+			};
+
+			buildDeps = with pkgs; [
+				cmakeCurses
+				pkg-config
+				ninja
+				coreutils
+
+				gdb
+				lldb
+			];
+		in rec {
+			# This block here is used when running `nix develop`
+			devShells.default = pkgs.mkShell  {
+				# Update the name to something that suites your project.
+				name				= "wjelement";
+				buildInputs			= buildDeps;
+				packages			= buildDeps;
+			};
+
+			# Build with `nix build`
+			packages.wjelement = pkgs.stdenv.mkDerivation {
+				name				= "wjelement";
+				buildInputs			= buildDeps;
+				version				= "1.3";
+				src					= ./.;
+
+				cmakeFlags			= [ ];
+
+				meta = {
+					homepage		= "https://github.com/netmail-open/wjelement";
+					description		= "JSON manipulation in C";
+					license			= pkgs.lib.licenses.mit;
+					platforms		= pkgs.lib.platforms.linux;
+				};
+			};
+			packages.default		= packages.wjelement;
+
+		}
+	);
+}


### PR DESCRIPTION
Add a flake for nix.

The flake allows building or developing on NixOS or on any other Linux or macOS system with nix installed. This includes a development environment (run `nix develop` to use) and a derivation (build with `nix build`).